### PR TITLE
Change default DMA channel to 10

### DIFF
--- a/ws2811.go
+++ b/ws2811.go
@@ -22,8 +22,8 @@ package ws2811
 import "github.com/pkg/errors"
 
 const (
-	// DefaultDmaNum is the default DMA number. Usually, this is 5 ob the Raspberry Pi
-	DefaultDmaNum = 5
+	// DefaultDmaNum is the default DMA number.
+	DefaultDmaNum = 10
 	// RpiPwmChannels is the number of PWM leds in the Raspberry Pi
 	RpiPwmChannels = 2
 	// TargetFreq is the target frequency. It is usually 800kHz (800000), and an go as low as 400000


### PR DESCRIPTION
As shown in [this](https://github.com/jgarff/rpi_ws281x/commit/749c6cfd26035679da21476f356ea8d8046dde1b) commit, the root library follows this same default for general safety.