### PR TITLE
fixed typo

### DIFF
--- a/examples/swiss/swiss.go
+++ b/examples/swiss/swiss.go
@@ -43,7 +43,7 @@ func main() {
 	defer dev.Fini()
 
 	for x := 0; x < width; x++ {
-		for y := 0; y < width; y++ {
+		for y := 0; y < height; y++ {
 			color := uint32(0xff0000)
 			if x > 2 && x < 5 && y > 0 && y < 7 {
 				color = 0xffffff


### PR DESCRIPTION
Fixed typo in swiss example. It's irrelevant for the example itself because it's a square pattern there but important to those who will reuse it as a base for their projects.