### PR TITLE
Support for arm64

### DIFF
--- a/ws2811_hw.go
+++ b/ws2811_hw.go
@@ -17,7 +17,7 @@
 // libws2811.a in a GCC library path (e.g. /usr/local/lib).
 // See https://github.com/jgarff/rpi_ws281x for instructions
 
-// +build arm
+// +build arm arm64
 
 package ws2811
 

--- a/ws2811_sim.go
+++ b/ws2811_sim.go
@@ -17,7 +17,7 @@
 // libws2811.a in a GCC library path (e.g. /usr/local/lib).
 // See https://github.com/jgarff/rpi_ws281x for instructions
 
-// +build !arm
+// +build !arm,!arm64
 
 package ws2811
 


### PR DESCRIPTION
Addresses #13 

This PR modifies build tags for `ws2811_sim.go` and `ws2811_arm.go` *(also renamed to ws2811_hw.go)* to support building for arm64 targets like the Raspberry Pi 4B

This has been tested, and works directly compiling on a Raspberry Pi 4B running Ubuntu 20.10 server for arm64.